### PR TITLE
Rename package to @robotlegsjs/phaser-ce-signalcommandmap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 node_js:
   - stable
 env:
-  - CODECLIMATE_REPO_TOKEN=9a7f560e5bf9614b96e1731ede6d48bfb7b41b9f9bb1be806eb33f59aebdbf76
-  - CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage CODECLIMATE_REPO_TOKEN=c8db23f8-561c-4839-9f74-1d704e27fadb
+  - CODECLIMATE_REPO_TOKEN=59198deafe4cc9d533a49973750025ad91928e95f55eafee8f94b1d64b60d2bc
+  - CODECLIMATE_API_HOST=https://codebeat.co/webhooks/code_coverage CODECLIMATE_REPO_TOKEN=63c28e60-364c-4c4a-abc7-29384c45192a
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,68 +1,68 @@
-# RobotlegsJS Phaser SignalCommandMap Changelog
+# RobotlegsJS Phaser-CE SignalCommandMap Changelog
 
-## RobotlegsJS Phaser SignalCommandMap 0.1.0
+## RobotlegsJS Phaser-CE SignalCommandMap 0.2.0
 
-### v0.1.0
+### v0.2.0
 
-- Update @robotlegsjs/core to version 0.2.0 (see #44).
+- Update `@robotlegsjs/core` to version `0.2.0` (see [44](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/44)).
 
-- Update phaser-ce to version 2.11.0 (see #37).
+- Update `phaser-ce` to version `2.11.0` (see [37](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/37)).
 
-- Add changelog (see #30).
+- Add changelog (see [30](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/30)).
 
-- Add Code of Conduct (see #31).
+- Add Code of Conduct (see [31](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/31)).
 
-- Add Issue Template (see #32).
+- Add Issue Template (see [32](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/32)).
 
-- Add Pull Request Template (see #33).
+- Add Pull Request Template (see [33](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/33)).
 
-- Update codeclimate settings (see #34).
+- Update codeclimate settings (see [34](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/34)).
 
-- Update Prettier rules (see #35).
+- Update Prettier rules (see [35](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/35)).
 
-- Use `rimraf` instead of `rm -rf` (see #36).
+- Use `rimraf` instead of `rm -rf` (see [36](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/36)).
 
-- Update TypeScript Compiler Options (see #38, #42).
+- Update TypeScript Compiler Options (see [38](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/38), [42](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/42)).
 
-- Use [tslib](https://github.com/Microsoft/tslib) library to avoid duplicated declarations (see #42).
+- Use [tslib](https://github.com/Microsoft/tslib) library to avoid duplicated declarations (see [42](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/42)).
 
-- Enforce TSLint rules (see #39).
+- Enforce TSLint rules (see [39](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/39)).
 
-- Adopts year-agnostic copyright message (see #40).
+- Adopts year-agnostic copyright message (see [40](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/40)).
 
 - Update dev dependencies to latest version.
 
-## RobotlegsJS Phaser SignalCommandMap 0.0.1
+## RobotlegsJS Phaser SignalCommandMap 0.0.1 (published as `@robotlegsjs/phaser-signalcommandmap`)
 
 ### [v0.0.5](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/releases/tag/0.0.5) - 2017-09-26
 
-- Update @robotlegsjs/core to version 0.0.6 (see #9).
+- Update `@robotlegsjs/core` to version `0.0.6` (see [9](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/9)).
 
-- Update phaser-ce to version 2.8.8 (see #10).
+- Update `phaser-ce` to version `2.8.8` (see [10](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/10)).
 
-- Adapt to NPM [v5.0.0](http://blog.npmjs.org/post/161081169345/v500) (see #7).
+- Adapt to NPM [v5.0.0](http://blog.npmjs.org/post/161081169345/v500) (see [7](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/7)).
 
 - Update dev dependencies to latest version.
 
 ### [v0.0.4](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/releases/tag/0.0.4) - 2017-09-15
 
-- Update @robotlegsjs/core to version 0.0.5 (see #5).
+- Update `@robotlegsjs/core` to version `0.0.5` (see [5](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/5)).
 
-- Update phaser-ce to version 2.8.7 (see #6).
+- Update `phaser-ce` to version `2.8.7` (see [6](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/6)).
 
-- Update TSLint rules (see #6).
+- Update TSLint rules (see [6](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/6)).
 
-- Add support to [Prettier](https://prettier.io) code formatter (see #6).
+- Add support to [Prettier](https://prettier.io) code formatter (see [6](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/6)).
 
-- Add integration with [CodeBeat](https://codebeat.co) (see #6).
+- Add integration with [CodeBeat](https://codebeat.co) (see [6](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/6)).
 
 - Update dev dependencies to latest version.
 
 ### [v0.0.3](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/releases/tag/0.0.3) - 2017-08-30
 
-- Update @robotlegsjs/core to version 0.0.4 (see #4).
+- Update `@robotlegsjs/core` to version `0.0.4` (see [4](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/4)).
 
-- Update phaser-ce to version 2.8.4.
+- Update `phaser-ce` to version `2.8.4`.
 
 - Enable GreenKeeper.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ### v0.2.0
 
+Major Breaking Changes:
+---
+
+- Rename package to `@robotlegsjs/phaser-ce-signalcommandmap` and move to [RobotlegsJS-Phaser-CE-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap) (see #1).
+
 - Update `@robotlegsjs/core` to version `0.2.0` (see [44](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/44)).
+
+Features Or Improvements:
+---
 
 - Update `phaser-ce` to version `2.11.0` (see [37](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/37)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ Features Or Improvements:
 
 - Update dev dependencies to latest version.
 
-## RobotlegsJS Phaser SignalCommandMap 0.0.1 (published as `@robotlegsjs/phaser-signalcommandmap`)
+## RobotlegsJS Phaser SignalCommandMap 0.0.1
+
+_(published as `@robotlegsjs/phaser-signalcommandmap`)_
 
 ### [v0.0.5](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/releases/tag/0.0.5) - 2017-09-26
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to RobotlegsJS-Phaser-SignalCommandMap
+# Contributing to RobotlegsJS-Phaser-CE-SignalCommandMap
 
 ## Setup
 
 1 - Clone your fork of the repository:
 ```
-$ git clone https://github.com/YOUR_USERNAME/RobotlegsJS-Phaser-SignalCommandMap.git
+$ git clone https://github.com/YOUR_USERNAME/RobotlegsJS-Phaser-CE-SignalCommandMap.git
 ```
 
 2 - Install npm dependencies using yarn:
@@ -43,4 +43,4 @@ changes.
 
 - Feel free to ask for help from other members of the RobotlegsJS team via the
 [gitter chat](https://gitter.im/RobotlegsJS/RobotlegsJS) or
-[github issues](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/issues).
+[github issues](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap/issues).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
-RobotlegsJS Phaser SignalCommandMap Extension
+RobotlegsJS Phaser-CE SignalCommandMap Extension
 ===
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/blob/master/LICENSE)
 [![Gitter chat](https://badges.gitter.im/RobotlegsJS/RobotlegsJS.svg)](https://gitter.im/RobotlegsJS/RobotlegsJS)
-[![Build Status](https://secure.travis-ci.org/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap.svg?branch=master)](https://travis-ci.org/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap)
-[![codebeat badge](https://codebeat.co/badges/c8db23f8-561c-4839-9f74-1d704e27fadb)](https://codebeat.co/projects/github-com-robotlegsjs-robotlegsjs-phaser-signalcommandmap-master)
-[![Test Coverage](https://codeclimate.com/github/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/badges/coverage.svg)](https://codeclimate.com/github/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/coverage)
-[![npm version](https://badge.fury.io/js/%40robotlegsjs%2Fphaser-signalcommandmap.svg)](https://badge.fury.io/js/%40robotlegsjs%2Fphaser-signalcommandmap)
-[![Greenkeeper badge](https://badges.greenkeeper.io/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap.svg)](https://greenkeeper.io/)
+[![Build Status](https://travis-ci.org/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap.svg?branch=master)](https://travis-ci.org/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap)
+[![codebeat badge](https://codebeat.co/badges/63c28e60-364c-4c4a-abc7-29384c45192a)](https://codebeat.co/projects/github-com-robotlegsjs-robotlegsjs-phaser-ce-signalcommandmap-master)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/be8024a4f08a2f6bdfc0/test_coverage)](https://codeclimate.com/github/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap/test_coverage)
+[![npm version](https://badge.fury.io/js/%40robotlegsjs%2Fphaser-ce-signalcommandmap.svg)](https://badge.fury.io/js/%40robotlegsjs%2Fphaser-ce-signalcommandmap)
+[![Greenkeeper badge](https://badges.greenkeeper.io/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap.svg)](https://greenkeeper.io/)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 A RobotlegsJS Extension that allows the mapping of Phaser.Signal class to commands.
+
+Installation
+---
+
+You can get the latest release and the type definitions using [NPM](https://www.npmjs.com/):
+
+```bash
+npm install @robotlegsjs/phaser-ce-signalcommandmap --save-prod
+```
+
+Or using [Yarn](https://yarnpkg.com/en/):
+
+```bash
+yarn add @robotlegsjs/phaser-ce-signalcommandmap
+```
+
+Then follow the [installation instructions](https://github.com/RobotlegsJS/RobotlegsJS/blob/master/README.md#installation) of **RobotlegsJS** library to complete the setup of your project.
+
+License
+---
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ RobotlegsJS Phaser-CE SignalCommandMap Extension
 [![Greenkeeper badge](https://badges.greenkeeper.io/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap.svg)](https://greenkeeper.io/)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
-A RobotlegsJS Extension that allows the mapping of Phaser.Signal class to commands.
+A [RobotlegsJS](https://github.com/RobotlegsJS/RobotlegsJS) Extension that allows the mapping of
+[Phaser.Signal](https://photonstorm.github.io/phaser-ce/Phaser.Signal.html) class to commands.
 
 Installation
 ---

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@robotlegsjs/phaser-signalcommandmap",
+  "name": "@robotlegsjs/phaser-ce-signalcommandmap",
   "version": "0.0.5",
   "description": "SignalCommandMap RobotlegsJS Extension that maps Phaser.Signal class into commands",
   "main": "lib/index.js",
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap.git"
+    "url": "git@github.com:RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap.git"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -32,7 +32,9 @@
   "keywords": [
     "TypeScript",
     "Robotlegs",
-    "IoC"
+    "IoC",
+    "Phaser-CE",
+    "Phaser.Signal"
   ],
   "author": "RobotlegsJS",
   "contributors": [
@@ -41,9 +43,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/issues"
+    "url": "https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap/issues"
   },
-  "homepage": "https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap#readme",
+  "homepage": "https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap#readme",
   "dependencies": {
     "@robotlegsjs/core": "^0.2.0",
     "phaser-ce": "^2.11.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = env => {
   let mode = env.production ? "production" : "development";
   let tsconfig = !env.karma ? "tsconfig.json" : "tsconfig.test.json";
   let output = env.production ? "dist" : "dist-test";
-  let filename = env.production ? "robotlegs-phaser-signalcommandmap.min.js" : "robotlegs-phaser-signalcommandmap.js";
+  let filename = env.production ? "robotlegs-phaser-ce-signalcommandmap.min.js" : "robotlegs-phaser-ce-signalcommandmap.js";
 
   return {
     mode: mode,
@@ -23,7 +23,7 @@ module.exports = env => {
       filename: filename,
 
       libraryTarget: "var",
-      library: "RobotlegsJSPhaserSignalCommandMap"
+      library: "RobotlegsJSPhaserCESignalCommandMap"
     },
 
     devtool: env.production ? undefined : "inline-source-map",

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,8 +464,10 @@ asn1.js@^4.0.0:
     minimalistic-assert "^1.0.0"
 
 asn1@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
+  version "0.2.4"
+  resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  dependencies:
+    safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -872,6 +874,21 @@ browserify-zlib@^0.2.0:
   resolved "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
   dependencies:
     pako "~1.0.5"
+
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+
+buffer-alloc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
@@ -3472,8 +3489,10 @@ isarray@2.0.1:
   resolved "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
 
 isbinaryfile@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz#4a3e974ec0cba9004d3fc6cde7209ea69368a621"
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz#5d6def3edebf6e8ca8cae9c30183a804b5f8be80"
+  dependencies:
+    buffer-alloc "^1.2.0"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -5707,7 +5726,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 


### PR DESCRIPTION
Rename package to `@robotlegsjs/phaser-ce-signalcommandmap` to keep compatibility with [Phaser-CE](https://github.com/photonstorm/phaser-ce).