### PR TITLE
Move phaser-ce library to peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Major Breaking Changes:
 
 - Rename package to `@robotlegsjs/phaser-ce-signalcommandmap` and move to [RobotlegsJS-Phaser-CE-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap) (see #1).
 
+- Move `phaser-ce` library to **peerDependencies**, allowing the final user to choose the desired version of the `phaser-ce` library on each project (see #3).
+
 - Update `@robotlegsjs/core` to version `0.2.0` (see [44](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-SignalCommandMap/pull/44)).
 
 Features Or Improvements:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,34 @@ Or using [Yarn](https://yarnpkg.com/en/):
 yarn add @robotlegsjs/phaser-ce-signalcommandmap
 ```
 
+From version `0.2.0` of this package, the [Phaser-CE](https://github.com/photonstorm/phaser-ce) dependency was moved to **peerDependencies**,
+allowing the final user to choose the desired version of the `phaser-ce` library on each project.
+
+The `@robotlegsjs/phaser-ce-signalcommandmap` package is compatible with versions between the `>=2.8.1 <3` version range of `phaser-ce` library.
+
+As example, when you would like to use the version `2.8.1` of `phaser-ce` library, you can run:
+
+```bash
+npm install phaser-ce@2.8.1 reflect-metadata --save-prod
+```
+
+or
+
+```bash
+yarn add phaser-ce@2.8.1 reflect-metadata
+```
+
 Then follow the [installation instructions](https://github.com/RobotlegsJS/RobotlegsJS/blob/master/README.md#installation) of **RobotlegsJS** library to complete the setup of your project.
+
+**Dependencies**
+
++ [RobotlegsJS](https://github.com/RobotlegsJS/RobotlegsJS)
++ [tslib](https://github.com/Microsoft/tslib)
+
+**Peer Dependencies**
+
++ [Phaser-CE](https://github.com/photonstorm/phaser-ce)
++ [reflect-metadata](https://github.com/rbuckton/reflect-metadata)
 
 License
 ---

--- a/package.json
+++ b/package.json
@@ -48,8 +48,11 @@
   "homepage": "https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap#readme",
   "dependencies": {
     "@robotlegsjs/core": "^0.2.0",
-    "phaser-ce": "^2.11.0",
     "tslib": "^1.9.3"
+  },
+  "peerDependencies": {
+    "phaser-ce": "^2.8.1",
+    "reflect-metadata": "^0.1.12"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.23",
@@ -80,6 +83,7 @@
     "karma-sourcemap-writer": "^0.1.2",
     "karma-webpack": "^3.0.0",
     "mocha": "^5.2.0",
+    "phaser-ce": "^2.11.0",
     "prettier": "^1.14.0",
     "publish-please": "^3.2.0",
     "reflect-metadata": "^0.1.12",
@@ -95,8 +99,5 @@
     "webpack": "^4.16.4",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.5"
-  },
-  "peerDependencies": {
-    "reflect-metadata": "^0.1.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,8 +1248,8 @@ commander@2.15.1:
   resolved "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 commander@^2.12.1, commander@^2.15.1, commander@^2.9.0:
-  version "2.16.0"
-  resolved "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
+  version "2.17.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-2.17.0.tgz#9d07b25e2a6f198b76d8b756a0e8a9604a6a1a60"
 
 commander@~2.13.0:
   version "2.13.0"


### PR DESCRIPTION
Move `phaser-ce` library to **peerDependencies**, allowing the final user to choose the desired version of the `phaser-ce` library on each project.